### PR TITLE
feat: realtime at response

### DIFF
--- a/at_command.go
+++ b/at_command.go
@@ -25,6 +25,7 @@ type ATCommand struct {
 	Processed    []string
 	Error        error
 	ResponseChan chan string
+	Urc          bool
 
 	Desired []string
 	Fault   []string
@@ -41,6 +42,7 @@ func NewATCommand(command string) *ATCommand {
 		Timeout:      5,
 		LineEnd:      true,
 		ResponseChan: nil,
+		Urc:          false,
 	}
 }
 

--- a/at_command.go
+++ b/at_command.go
@@ -20,10 +20,11 @@ func DefaultSerialAttr() SerialAttr {
 type ATCommand struct {
 	SerialAttr SerialAttr
 
-	Command   string
-	Response  []string
-	Processed []string
-	Error     error
+	Command      string
+	Response     []string
+	Processed    []string
+	Error        error
+	ResponseChan chan string
 
 	Desired []string
 	Fault   []string
@@ -33,12 +34,13 @@ type ATCommand struct {
 
 func NewATCommand(command string) *ATCommand {
 	return &ATCommand{
-		SerialAttr: DefaultSerialAttr(),
-		Command:    command,
-		Desired:    nil,
-		Fault:      nil,
-		Timeout:    5,
-		LineEnd:    true,
+		SerialAttr:   DefaultSerialAttr(),
+		Command:      command,
+		Desired:      nil,
+		Fault:        nil,
+		Timeout:      5,
+		LineEnd:      true,
+		ResponseChan: nil,
 	}
 }
 

--- a/atcom.go
+++ b/atcom.go
@@ -173,14 +173,19 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 						line = strings.Trim(line, "\r")
 						line = strings.Trim(line, "\n")
 
+						if line != "" {
+							data = append(data, line)
+							c.ResponseChan <- line
+						}
+
 						if strings.Contains(line, "ERROR") {
 							found <- errors.New(line)
 							break
 						}
 
-						if line != "" {
-							data = append(data, line)
-							c.ResponseChan <- line
+						if strings.Contains(line, "OK") {
+							found <- nil
+							break
 						}
 					}
 					// Read responses continuously until timeout is reached

--- a/atcom.go
+++ b/atcom.go
@@ -111,6 +111,7 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 	portname := c.SerialAttr.Port
 	baudrate := c.SerialAttr.Baud
 	responseChan := c.ResponseChan
+	urc := c.Urc
 
 	serialPort, err := t.open(portname, baudrate)
 
@@ -125,7 +126,10 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 		command += "\r\n"
 	}
 
-	_, err = t.serial.Write(serialPort, []byte(command))
+	if !urc {
+		_, err = t.serial.Write(serialPort, []byte(command))
+	}
+
 	if err != nil {
 		c.Error = err
 		return c

--- a/atcom.go
+++ b/atcom.go
@@ -126,6 +126,7 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 		command += "\r\n"
 	}
 
+	// If urc is true, do not send command to serial port.
 	if !urc {
 		_, err = t.serial.Write(serialPort, []byte(command))
 	}
@@ -165,6 +166,7 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 				}
 
 				// Send real-time responses through the channel if ResponseChan is set
+				// Listen for responses until a timeout occurs or the desired response is received.
 				if responseChan != nil {
 					if n > 0 {
 						response = string(buf[:n])
@@ -209,7 +211,6 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 
 						}
 					}
-					// Read responses continuously until timeout is reached
 					continue
 				}
 

--- a/atcom.go
+++ b/atcom.go
@@ -187,6 +187,23 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 							found <- nil
 							break
 						}
+
+						// check desired and fault existed in response
+						if desired != nil || fault != nil {
+							for _, desiredStr := range desired {
+								if strings.Contains(line, desiredStr) {
+									found <- nil
+									return
+								}
+							}
+							for _, faultStr := range fault {
+								if strings.Contains(line, faultStr) {
+									found <- errors.New("faulty response detected")
+									return
+								}
+							}
+
+						}
 					}
 					// Read responses continuously until timeout is reached
 					continue

--- a/atcom.go
+++ b/atcom.go
@@ -100,56 +100,6 @@ func (t *Atcom) open(portname string, baudrate int) (port *serial.Port, err erro
 	return t.serial.OpenPort(config)
 }
 
-// Function to read serial port
-func (t *Atcom) ReadResponse(c *ATCommand) error {
-	timeout := c.Timeout
-	portname := c.SerialAttr.Port
-	baudrate := c.SerialAttr.Baud
-	responseChan := c.ResponseChan
-
-	serialPort, err := t.open(portname, baudrate)
-	if err != nil {
-		return err
-	}
-	defer t.serial.Close(serialPort)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-	defer cancel()
-
-	done := make(chan error, 1)
-
-	go func() {
-		buf := make([]byte, 1024)
-		for {
-			select {
-			case <-ctx.Done():
-				done <- nil
-				return
-			default:
-				n, err := t.serial.Read(serialPort, buf)
-				if err != nil {
-					if err.Error() == "EOF" {
-						continue
-					}
-					done <- err
-					return
-				}
-				if n > 0 {
-					response := string(buf[:n])
-					responseChan <- response
-				}
-			}
-		}
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-ctx.Done():
-		return nil
-	}
-}
-
 // SendAT sends AT command to modem and returns response
 func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 

--- a/atcom.go
+++ b/atcom.go
@@ -173,9 +173,13 @@ func (t *Atcom) SendAT(c *ATCommand) *ATCommand {
 						line = strings.Trim(line, "\r")
 						line = strings.Trim(line, "\n")
 
+						if strings.Contains(line, "ERROR") {
+							found <- errors.New(line)
+							break
+						}
+
 						if line != "" {
 							data = append(data, line)
-
 							c.ResponseChan <- line
 						}
 					}

--- a/pkg/cli/cmd/cli.go
+++ b/pkg/cli/cmd/cli.go
@@ -240,7 +240,7 @@ func init() {
 	rootCmd.Flags().IntP("timeout", "t", 5, "timeout duration in seconds")
 	rootCmd.Flags().BoolP("lineend", "l", true, "line end")
 	rootCmd.Flags().BoolP("verbose", "v", false, "verbose mode")
-	rootCmd.Flags().BoolP("urc", "u", false, "unsolicited response code")
+	rootCmd.Flags().BoolP("urc", "u", false, "unsolicited response code - if this flag is set, command will not be sent to modem")
 	rootCmd.Flags().StringP("version", "V", "", "version")
 
 	rootCmd.AddCommand(versionCmd)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package atcom
 
-const Version = "v0.5.4"
+const Version = "v0.6.0"


### PR DESCRIPTION
# Summary
This PR introduces support for **URC** (Unsolicited Result Code) mode and **real-time** AT response listening. When URC mode is enabled, the program listens for unsolicited responses from the modem **without sending a command**. Real-time listening through a channel allows the program to continuously receive and process incoming messages. These improvements enhance the ability to monitor unsolicited responses and handle data in real time.

# Changes

- **URC Mode:** URC mode support has been added to the codebase. A new urc property is introduced in the ATCommand struct in atcom.go. When the urc property is set to true, the program listens for unsolicited responses from the modem **without sending any commands**. This helps in monitoring the modem without initiating new commands.  Default is false.

- **ResponseChan:** A new responseChan property is added to the ATCommand struct. This channel is used to stream responses received from the modem, allowing for real-time access to all messages.

- **Verbose Mode:** The existing verbose mode functionality is extended. When enabled, it prints parameters and responses until the timeout period, desired response, or standard responses (OK/ERROR) are received.

- **SendAT Function in `atcom.go`:** The SendAT() function has been updated to handle the new urc and responseChan properties, allowing for the listening of unsolicited responses and streaming of modem responses to the provided channel.