### PR TITLE
refactor: separate URC handling into a standalone command

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package atcom
 
-const Version = "v0.6.0"
+const Version = "v0.6.1"


### PR DESCRIPTION
## Changes

- Extracted URC handling from `rootCmd` and introduced a dedicated `urcCmd`.

- Removed the --urc flag from rootCmd, as **URC** is now a separate command.

- Added specific flags (port, baud, desired, fault, timeout, lineend) to `urcCmd` for better configurability.